### PR TITLE
I've adjusted the bot schedule to TRT (UTC+3) 12:00-18:00.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Telegram Instagram Bot CI
 
 on:
   schedule:
-    - cron: '0 12 * * *' # Her gün UTC 12:00'de çalıştır
+    - cron: '0 9 * * *' # Her gün UTC 09:00'da (TR saati ile 12:00) çalıştır
   workflow_dispatch: # Manuel tetikleme için
 
 jobs:


### PR DESCRIPTION
- I updated the GitHub Actions workflow cron to trigger at 09:00 UTC daily to align with 12:00 TRT.
- I kept the timeout at 358 minutes for approximately 6 hours of runtime.