### PR TITLE
To enable Instagram video downloading, I've switched from Instaloader…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 python-telegram-bot==13.7
-instaloader
+yt-dlp


### PR DESCRIPTION
… to yt-dlp. Here's what I did:

- I replaced `instaloader` with `yt-dlp` in your `requirements.txt` file.
- I rewrote `bot.py` to use `yt-dlp` via `subprocess` for video downloads.
- I implemented temporary cookie file generation from `INSTAGRAM_SESSIONID` for `yt-dlp`.
- I updated your download logic, error handling, and temporary file cleanup to work with `yt-dlp`.
- I modified the user messages in `start_command` to reflect the change.