### PR TITLE
It looks like I've made the following changes:

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,11 @@ jobs:
       with:
         python-version: '3.11' # Dockerfile'daki sürümle uyumlu veya projenin gerektirdiği sürüm
 
+    - name: Install ffmpeg
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y ffmpeg
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/bot.py
+++ b/bot.py
@@ -122,9 +122,12 @@ def link_handler(update: Update, context: CallbackContext):
         '--socket-timeout', '30', # 30 saniye
         # '--retries', '3', # Deneme sayısı (isteğe bağlı)
         '-o', os.path.join(download_dir, '%(id)s.%(ext)s'), # Çıktı şablonu
-        # Video formatı (önce mp4 dene, sonra en iyisi)
-        # En iyi video ve sesi birleştir, eğer mp4 ise direkt onu al.
-        '-f', 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best',
+        # Video formatı:
+        # 1. En iyi mp4 video + en iyi m4a sesi birleştir.
+        # 2. Olmazsa, en iyi mp4 (sesli veya sessiz) al.
+        # 3. Olmazsa, en iyi video (herhangi bir format) + en iyi sesi (herhangi bir format) birleştir.
+        # 4. Olmazsa, en iyi (sesli veya sessiz, herhangi bir format) al.
+        '-f', 'bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/bv*+ba/b',
     ]
 
     if cookie_file:


### PR DESCRIPTION
- I added a step to install ffmpeg in the GitHub Actions workflow. This should allow yt-dlp to merge video and audio streams.
- I also updated the yt-dlp format selection string in `bot.py`. I made it more flexible and it now prioritizes combined audio/video. My goal here was to resolve issues you might have been seeing with silent videos.