### PR TITLE
Feat: Implement Koyeb-triggered GitHub Actions architecture

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,49 +1,145 @@
-name: Telegram Instagram Bot CI
+name: Instagram Video Downloader Action
 
 on:
-  schedule:
-    - cron: '0 9 * * *' # Her gün UTC 09:00'da (TR saati ile 12:00) çalıştır
-  workflow_dispatch: # Manuel tetikleme için
+  workflow_dispatch:
+    inputs:
+      instagram_url:
+        description: 'Instagram video URL to download'
+        required: true
+        type: string
+      chat_id:
+        description: 'Telegram Chat ID to send the video to'
+        required: true
+        type: string
 
 jobs:
-  run-bot:
+  download-and-send:
     runs-on: ubuntu-latest
+    # Timeout'u tek bir indirme işlemi için daha kısa tutalım, örn: 20 dakika
+    timeout-minutes: 20
     env:
-      TELEGRAM_TOKEN: ${{ secrets.TELEGRAM_TOKEN }}
-      INSTAGRAM_SESSIONID: ${{ secrets.INSTAGRAM_SESSIONID }} # Opsiyonel, kullanıcı ayarlayabilir
+      # Bu secret, Koyeb'deki ana botun Telegram token'ı olacak
+      # ve Actions'ın videoyu kullanıcıya göndermesi için kullanılacak.
+      BOT_TOKEN_FOR_ACTIONS: ${{ secrets.BOT_TOKEN_FOR_ACTIONS }}
+      INSTAGRAM_SESSIONID: ${{ secrets.INSTAGRAM_SESSIONID }} # Opsiyonel
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4 # checkout@v3 veya @v4 kullanılabilir
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4 # setup-python@v3 veya @v4
       with:
-        python-version: '3.11' # Dockerfile'daki sürümle uyumlu veya projenin gerektirdiği sürüm
+        python-version: '3.11'
 
     - name: Install ffmpeg
       run: |
         sudo apt-get update -y
         sudo apt-get install -y ffmpeg
 
-    - name: Install dependencies
+    - name: Install dependencies (yt-dlp, requests)
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        # Sadece yt-dlp ve requests (eğer video gönderme script'i python ise) yeterli olacak
+        # requirements.txt tüm bot bağımlılıklarını içeriyorsa o da kullanılabilir.
+        # Şimdilik doğrudan kuralım:
+        pip install yt-dlp requests
 
-    - name: Run Telegram Bot
-      # timeout-minutes, tüm job adımlarının toplam süresidir.
-      # Eğer botun kendisi düzgün kapanmazsa, bu timeout onu sonlandıracaktır.
-      # Cron her gün UTC 12:00'de tetiklenecek ve bu adım yaklaşık 6 saat sonra (UTC 18:00 civarı) zaman aşımına uğrayacak.
-      timeout-minutes: 358 # Yaklaşık 5 saat 58 dakika
-      run: python bot.py
+    - name: Download Video using yt-dlp
+      id: download_video # Bu adıma bir id vererek çıktısını sonraki adımlarda kullanabiliriz
+      run: |
+        echo "Downloading video from: ${{ github.event.inputs.instagram_url }}"
 
-    - name: Clean up temporary files (if any left)
-      # Botun içindeki finally bloğu temizlik yapmalı, bu ek bir önlem.
+        cookie_file_path="temp_cookie_${{ github.run_id }}_${{ github.run_attempt }}.txt"
+        download_dir="temp_dl_${{ github.run_id }}_${{ github.run_attempt }}"
+        mkdir -p "$download_dir"
+
+        # Cookie dosyası oluşturma (eğer INSTAGRAM_SESSIONID varsa)
+        if [ -n "$INSTAGRAM_SESSIONID" ]; then
+          echo "Creating cookie file..."
+          expiration_timestamp=$(($(date +%s) + 10*365*24*60*60))
+          printf "# Netscape HTTP Cookie File\n" > "$cookie_file_path"
+          printf "# http://www.netscape.com/newsref/std/cookie_spec.html\n" >> "$cookie_file_path"
+          printf "# This is a generated file!  Do not edit.\n\n" >> "$cookie_file_path"
+          printf ".instagram.com\tTRUE\t/\tTRUE\t%s\tsessionid\t%s\n" "$expiration_timestamp" "$INSTAGRAM_SESSIONID" >> "$cookie_file_path"
+          cookie_arg="--cookies $cookie_file_path"
+        else
+          echo "No INSTAGRAM_SESSIONID provided, attempting anonymous download."
+          cookie_arg=""
+        fi
+
+        # yt-dlp komutu
+        # Çıktı dosya adını tahmin edilebilir yapmak için -o kullanalım ve sonra bu adı yakalayalım
+        # %(title)s veya %(id)s kullanılabilir. Uzantı yt-dlp tarafından belirlenir.
+        # Örnek: video_file.mp4
+        output_template="$download_dir/downloaded_video.%(ext)s"
+
+        echo "Running yt-dlp..."
+        yt-dlp_exit_code=0
+        # yt-dlp'nin çıktısını değişkene ata
+        download_output=$(yt-dlp --no-warnings --force-overwrites --no-playlist \
+          --socket-timeout 60 \
+          -o "$output_template" \
+          -f "bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/bv*+ba/b" \
+          $cookie_arg \
+          "${{ github.event.inputs.instagram_url }}" 2>&1) || yt-dlp_exit_code=$?
+
+        echo "$download_output"
+
+        if [ $yt_dlp_exit_code -ne 0 ]; then
+          echo "::error title=yt-dlp Error::Failed to download video. Exit code: $yt_dlp_exit_code. Output: $download_output"
+          # Hata mesajını Koyeb'deki bota (veya doğrudan kullanıcıya) göndermek zor olabilir.
+          # Şimdilik sadece Actions'ta hata olarak işaretleyelim.
+          # Koyeb'deki bot, Actions'ın başarılı olup olmadığını API ile sorgulayabilir veya timeout ile anlayabilir.
+          exit 1
+        fi
+
+        # İndirilen dosyanın tam adını bul
+        # `ls` komutuyla $download_dir içindeki dosyayı buluruz. Genelde tek dosya olmalı.
+        video_file_path=$(ls -1 "$download_dir"/*.* | head -n 1)
+        if [ -z "$video_file_path" ]; then
+          echo "::error title=File Not Found::Downloaded video file not found in $download_dir."
+          exit 1
+        fi
+        echo "Video downloaded to: $video_file_path"
+        echo "video_path=$video_file_path" >> $GITHUB_OUTPUT # Sonraki adımda kullanmak için
+
+    - name: Send Video to Telegram
+      env:
+        TELEGRAM_CHAT_ID: ${{ github.event.inputs.chat_id }}
+        # BOT_TOKEN_FOR_ACTIONS secret'ı yukarıda env altında tanımlı
+      run: |
+        echo "Sending video to chat ID: $TELEGRAM_CHAT_ID"
+        video_path="${{ steps.download_video.outputs.video_path }}"
+
+        if [ ! -f "$video_path" ]; then
+          echo "::error title=Video File Missing::Video file $video_path does not exist for sending."
+          exit 1
+        fi
+
+        # Telegram API'sine curl ile video gönderme
+        # Dosya boyutu Telegram limitlerini (50MB) aşabilir, bu kontrol edilebilir.
+        # Ancak şimdilik direkt göndermeyi deneyelim.
+        caption="Video requested for: ${{ github.event.inputs.instagram_url }}"
+
+        curl_response_code=$(curl -s -o /dev/null -w "%{http_code}" \
+          -F "chat_id=$TELEGRAM_CHAT_ID" \
+          -F "video=@$video_path" \
+          -F "caption=$caption" \
+          "https://api.telegram.org/bot$BOT_TOKEN_FOR_ACTIONS/sendVideo")
+
+        if [ "$curl_response_code" -eq 200 ]; then
+          echo "Video sent successfully to Telegram."
+        else
+          echo "::error title=Telegram API Error::Failed to send video to Telegram. HTTP status: $curl_response_code."
+          # Yanıtı da loglayabiliriz (eğer varsa)
+          # curl -s -v -F "chat_id=$TELEGRAM_CHAT_ID" ... (yanıtı görmek için)
+          exit 1
+        fi
+
+    - name: Clean up temporary files
       if: always() # Her zaman çalışsın (başarılı veya başarısız olsa da)
       run: |
-        echo "Temizlik yapılıyor (varsa kalan temp dosyaları)..."
-        # rm -rf temp_* # Bot scripti kendi temp dosyalarını sildiği için bu genellikle gerekmeyebilir.
-        # Ancak botun beklenmedik şekilde sonlanması durumunda kalıntıları temizlemek için eklenebilir.
-        # Şimdilik botun kendi temizliğine güveniyoruz.
-        echo "Temizlik tamamlandı."
+        echo "Cleaning up temporary files..."
+        rm -rf temp_dl_* temp_cookie_*
+        echo "Cleanup complete."

--- a/README.md
+++ b/README.md
@@ -1,91 +1,104 @@
-# Instagram Video İndirme Telegram Botu (GitHub Actions ile)
+# Instagram Video İndirme Telegram Botu (Koyeb + GitHub Actions)
 
-Bu proje, Telegram üzerinden gönderilen Instagram video linklerini indirip kullanıcıya gönderen bir Python botudur. Bot, GitHub Actions kullanılarak zamanlanmış görevlerle çalışır ve belirli saatlerde aktif olur.
+Bu proje, Telegram üzerinden gönderilen Instagram video linklerini işleyerek, video indirme görevini GitHub Actions'a yaptıran ve sonucu kullanıcıya gönderen bir mimari sunar. Ana Telegram bot mantığı Koyeb üzerinde sürekli çalışırken, ağır yük olan video indirme ve işleme GitHub Actions üzerinde isteğe bağlı olarak gerçekleştirilir.
 
-**Bot Linki:** [IGXDOWN Bot](https://t.me/igxdown_bot)
+**Bot Linki:** [IGXDOWN Bot](https://t.me/igxdown_bot) (Bu link, sizin deploy ettiğiniz botun linki olmalıdır)
 
-## Özellikler
+## Mimarinin Özellikleri
 
--   Instagram Reel ve video gönderilerini `yt-dlp` kullanarak indirir.
--   Kullanımı kolay Telegram bot arayüzü.
--   GitHub Actions ile sunucusuz (serverless) çalışma.
--   Belirlenmiş zaman aralıklarında (örneğin her gün 6 saat) otomatik çalışma.
--   `ffmpeg` kullanarak video ve ses akışlarını birleştirme (sesli indirme için).
--   Opsiyonel `INSTAGRAM_SESSIONID` kullanımı (geliştiriciler veya özel durumlar için).
+-   **İstek Üzerine Çalışan Video İşleme:** GitHub Actions sadece bir indirme talebi geldiğinde tetiklenir, kaynakları verimli kullanır.
+-   **Sürekli Aktif Bot Arayüzü:** Koyeb üzerinde çalışan ana bot, kullanıcılardan her zaman istek alabilir.
+-   **Ölçeklenebilir İndirme:** Yoğun indirme işlemleri GitHub'ın altyapısında gerçekleşir.
+-   **`yt-dlp` ve `ffmpeg` Kullanımı:** Videolar `yt-dlp` ile indirilir, video/ses birleştirme için `ffmpeg` kullanılır (GitHub Actions'ta otomatik kurulur).
+-   **Opsiyonel `INSTAGRAM_SESSIONID`:** Gelişmiş durumlar veya özel videolar için GitHub Actions secret'ı olarak `INSTAGRAM_SESSIONID` tanımlanabilir.
 
 ## Nasıl Çalışır?
 
-Bu bot, `python-telegram-bot` kütüphanesi ile Telegram API'sine bağlanır. Instagram içeriklerini indirmek için ise popüler ve güçlü bir komut satırı aracı olan `yt-dlp` kullanılır. `yt-dlp`, `bot.py` scripti içerisinden `subprocess` modülü aracılığıyla çalıştırılır.
+1.  **Kullanıcı Etkileşimi (Telegram):** Kullanıcı, Telegram botuna bir Instagram video linki gönderir.
+2.  **Ana Bot (Koyeb):**
+    *   Koyeb üzerinde sürekli çalışan Python tabanlı Telegram botu (`bot.py`) bu isteği alır.
+    *   Kullanıcıya isteğin alındığına dair bir mesaj gönderir.
+    *   GitHub API'sine bir `workflow_dispatch` isteği göndererek `.github/workflows/main.yml` adlı GitHub Actions workflow'unu tetikler. Bu istek, indirilecek Instagram URL'sini ve kullanıcının Telegram Chat ID'sini `inputs` olarak Actions'a iletir.
+3.  **Video İşleme (GitHub Actions):**
+    *   GitHub Actions workflow'u tetiklenir.
+    *   Gerekli bağımlılıkları (`yt-dlp`, `ffmpeg` vb.) kurar.
+    *   Eğer `INSTAGRAM_SESSIONID` (Actions secret olarak tanımlıysa) varsa, bunu kullanarak bir cookie dosyası oluşturur.
+    *   `yt-dlp` aracılığıyla verilen Instagram URL'sinden videoyu indirir.
+    *   İndirilen videoyu, `BOT_TOKEN_FOR_ACTIONS` (Koyeb'deki botunuzun Telegram token'ını içeren bir Actions secret'ı) kullanarak ve `inputs` ile gelen `chat_id`'ye doğrudan Telegram üzerinden gönderir.
+    *   İşlem bittikten sonra tüm geçici dosyaları siler.
+4.  **Sonuç (Telegram):** Kullanıcı, videoyu doğrudan Telegram üzerinden alır.
 
-Eğer indirilen video ve ses ayrı akışlar halindeyse, `yt-dlp` bu akışları birleştirmek için `ffmpeg` aracını kullanır. Bu nedenle, `ffmpeg` de GitHub Actions iş akışında otomatik olarak kurulmaktadır.
+## Kurulum ve Kullanım (Bu Depoyu Forklayarak Kendi Botunuzu Oluşturmak İçin)
 
-### Zamanlama ve Çalışma Prensibi
+Bu mimariyi kendi hesabınızda kurmak için aşağıdaki adımları izleyin:
 
-Bot, GitHub Actions üzerinde bir cron job ile **her gün Türkiye saati ile 12:00'de (UTC 09:00)** otomatik olarak çalışmaya başlar ve yaklaşık **6 saat boyunca (Türkiye saati ile 18:00'e kadar, UTC 15:00)** aktif kalır. Bu süre sonunda GitHub Actions iş akışı otomatik olarak sonlanır.
-
-Bu zamanlama, `.github/workflows/main.yml` dosyasındaki `schedule: - cron: '0 9 * * *'` (her gün UTC 09:00'da çalıştır) ve `run-bot` işindeki `timeout-minutes: 358` (yaklaşık 6 saatlik çalışma süresi) ayarları ile yönetilir.
-
-### Instagram İndirme Mantığı
-
-Bot, bir Instagram linki aldığında aşağıdaki adımları izler:
-1.  Eğer `INSTAGRAM_SESSIONID` ortam değişkeni (GitHub Secrets aracılığıyla) ayarlanmışsa, bu `sessionid` kullanılarak geçici bir cookie dosyası oluşturulur ve `yt-dlp`'ye bu dosya `--cookies` parametresi ile verilir. Bu, özel veya giriş gerektiren bazı videoların indirilmesine yardımcı olabilir.
-2.  `yt-dlp`, verilen URL'yi ve (varsa) cookie dosyasını kullanarak videoyu indirmeye çalışır. Mümkün olan en iyi kalitede MP4 video ve sesi birleştirmeye çalışır.
-3.  İndirme işlemi başarılı olursa, video kullanıcıya Telegram üzerinden gönderilir.
-4.  Tüm geçici dosyalar (cookie dosyası, indirilen video) işlem sonunda otomatik olarak silinir.
-
-Genel kullanıcıların `INSTAGRAM_SESSIONID` ayarlamasına gerek yoktur; bot, ayarlanmamışsa anonim olarak indirme deneyecektir. Ancak, bazı videoların (örneğin özel hesaplara ait olanlar) sadece geçerli bir `sessionid` ile indirilebileceği unutulmamalıdır.
-
-## Kurulum ve Kullanım
-
-Bu botu kendi Telegram hesabınızla kullanmak için aşağıdaki adımları izleyin:
+### 1. GitHub Tarafı Ayarları
 
 1.  **Bu Depoyu Forklayın:** Bu GitHub deposunu kendi hesabınıza forklayın.
-2.  **Telegram Bot Token'ı Alın:**
-    *   Telegram'da [BotFather](https://t.me/BotFather) ile konuşun.
-    *   Yeni bir bot oluşturmak için `/newbot` komutunu kullanın.
-    *   BotFather'ın size vereceği **API token**'ını kopyalayın. Bu token gizli tutulmalıdır.
-3.  **GitHub Secrets Ayarları:**
+2.  **GitHub Personal Access Token (PAT) Oluşturun:**
+    *   GitHub hesabınızda "Settings" > "Developer settings" > "Personal access tokens" > "Tokens (classic)" bölümüne gidin.
+    *   "Generate new token" (veya "Generate new token (classic)") seçin.
+    *   Token'a bir isim verin (örn: `KOYEB_ACTIONS_TRIGGER`).
+    *   "Expiration" (Sona Erme Tarihi) seçin (örneğin, "No expiration" veya belirli bir süre).
+    *   **`workflow`** scope'unu işaretleyin. Bu, token'ın Actions workflow'larını tetiklemesine izin verecektir.
+    *   "Generate token" butonuna tıklayın ve oluşturulan token'ı **hemen kopyalayın**. Bu token bir daha gösterilmeyecektir.
+3.  **GitHub Actions Secret'larını Ayarlayın:**
     *   Forkladığınız deponun GitHub sayfasına gidin.
     *   `Settings` > `Secrets and variables` > `Actions` sekmesine tıklayın.
     *   `New repository secret` butonuna tıklayarak aşağıdaki secret'ları ekleyin:
-        *   **`TELEGRAM_TOKEN`**: Değer olarak BotFather'dan aldığınız API token'ını yapıştırın.
-        *   **`INSTAGRAM_SESSIONID`** (Opsiyonel): Eğer özel videoları indirmek veya giriş sorunlarını aşmak istiyorsanız, buraya kendi Instagram `sessionid`'nizi ekleyebilirsiniz.
+        *   **`BOT_TOKEN_FOR_ACTIONS`**: Değer olarak, Koyeb'de çalışacak olan Telegram botunuzun BotFather'dan aldığınız **API token**'ını yapıştırın. Bu, Actions'ın videoyu Telegram'a gönderebilmesi için gereklidir.
+        *   **`INSTAGRAM_SESSIONID`** (Opsiyonel): Eğer özel videoları indirmek veya bazı erişim sorunlarını aşmak istiyorsanız, buraya kendi Instagram `sessionid`'nizi ekleyebilirsiniz. (Nasıl alınacağı aşağıda "Geliştiriciler İçin Notlar" bölümünde açıklanmıştır).
 
-4.  **GitHub Actions'ı Etkinleştirin:**
-    *   Forkladığınız deponun `Actions` sekmesine gidin.
-    *   Eğer bir uyarı görüyorsanız ("Workflows aren't running on this repository"), "I understand my workflows, go ahead and enable them" butonuna tıklayarak Actions'ı etkinleştirin.
+### 2. Telegram Bot Token'ı Alma (Eğer Yoksa)
 
-Bot artık belirlediğiniz zamanlarda otomatik olarak çalışmaya başlayacaktır.
+1.  Telegram'da [BotFather](https://t.me/BotFather) ile konuşun.
+2.  Yeni bir bot oluşturmak için `/newbot` komutunu kullanın ve talimatları izleyin.
+3.  BotFather'ın size vereceği **API token**'ını kopyalayın. Bu token hem Koyeb'de hem de yukarıdaki `BOT_TOKEN_FOR_ACTIONS` secret'ında kullanılacak.
+
+### 3. Koyeb Tarafı Ayarları
+
+1.  **Koyeb Hesabı Oluşturun/Giriş Yapın:** [Koyeb](https://www.koyeb.com/) adresine gidin.
+2.  **Yeni Bir Servis (App) Oluşturun:**
+    *   Deployment metodu olarak "GitHub" seçin.
+    *   Forkladığınız GitHub deposunu ve `main` dalını seçin.
+    *   **Build & Run Komutları:**
+        *   Koyeb, `requirements.txt` dosyasını otomatik olarak algılayıp bağımlılıkları yükleyecektir.
+        *   Çalıştırma komutu (Run command) olarak `python bot.py` girin.
+    *   **Ortam Değişkenleri (Environment Variables):**
+        *   `TELEGRAM_TOKEN`: BotFather'dan aldığınız API token.
+        *   `GITHUB_PAT`: GitHub'dan oluşturduğunuz Personal Access Token.
+        *   `GITHUB_OWNER`: GitHub kullanıcı adınız veya organizasyon adınız (forkladığınız deponun sahibi).
+        *   `GITHUB_REPO`: Forkladığınız deponun adı.
+        *   `GITHUB_WORKFLOW_ID`: Genellikle `.github/workflows/` altındaki YAML dosyasının adı (örn: `main.yml`).
+    *   Bölge (Region) seçin ve servisi deploy edin.
+3.  **Servisin Çalıştığından Emin Olun:** Koyeb loglarını kontrol ederek botunuzun başarıyla başladığını ve Telegram'dan mesajları dinlediğini doğrulayın.
+
+Artık Telegram botunuz Koyeb üzerinde çalışacak, gelen linkleri GitHub Actions'a ileterek video indirme işlemlerini orada yaptıracak ve sonuç kullanıcıya Actions tarafından gönderilecektir.
 
 ## Geliştiriciler İçin Notlar / İleri Düzey Kullanım
 
-### `INSTAGRAM_SESSIONID` Kullanımı (Opsiyonel)
+### `INSTAGRAM_SESSIONID` Kullanımı (Opsiyonel - Actions Secret'ı Olarak)
 
-Bu bot, genel kullanıcılar için `INSTAGRAM_SESSIONID` ayarlanmasını **gerektirmez**. Çoğu herkese açık video, `sessionid` olmadan da indirilebilir.
+Bu mimaride, `INSTAGRAM_SESSIONID` doğrudan Koyeb'deki bota değil, **GitHub Actions Secret**'larına eklenir. GitHub Actions workflow'u, bu secret tanımlıysa `yt-dlp` için bir cookie dosyası oluşturur.
 
-Ancak, aşağıdaki durumlarda `INSTAGRAM_SESSIONID` kullanmak faydalı veya gerekli olabilir:
--   **Özel (Private) Hesaplardan Video İndirme:** Eğer takip ettiğiniz özel bir hesaptan video indirmek istiyorsanız.
--   **Giriş Gerektiren Videolar:** Instagram'ın bazı videolar için giriş yapılmasını zorunlu kıldığı durumlar.
--   **Rate Limiting / Engelleme Sorunları:** Anonim isteklerin Instagram tarafından sık sık kısıtlandığı veya engellendiği durumlarda, geçerli bir `sessionid` kullanmak bu sorunları aşmaya yardımcı olabilir.
-
-Eğer bu depoyu forklayıp kendi botunuzu çalıştırıyorsanız ve yukarıdaki durumlar için `sessionid` kullanmak isterseniz, `INSTAGRAM_SESSIONID` adlı bir GitHub Secret oluşturarak kendi `sessionid` değerinizi buraya ekleyebilirsiniz. Bot, bu secret ayarlanmışsa otomatik olarak `yt-dlp`'ye cookie dosyası aracılığıyla iletecektir.
+Kullanım senaryoları:
+-   Özel (Private) Hesaplardan Video İndirme.
+-   Giriş Gerektiren Videolar.
+-   Rate Limiting / Engelleme Sorunlarını Aşma.
 
 **`INSTAGRAM_SESSIONID` Nasıl Alınır?**
-
+(Bu adımlar bir önceki README versiyonundaki gibidir)
 1.  Tarayıcınızda Instagram.com'a gidin ve hesabınıza giriş yapın.
-2.  Geliştirici araçlarını açın (genellikle F12 tuşu veya sağ tıklayıp "İncele" seçeneği).
-3.  `Application` (Chrome/Edge) veya `Storage` (Firefox) sekmesine gidin.
-4.  Sol menüden `Cookies` > `https://www.instagram.com` seçeneğini bulun.
-5.  Çerezler listesinde `sessionid` adlı çerezi bulun ve değerini kopyalayın.
-6.  Bu değeri, forklanmış deponuzdaki GitHub Secrets ayarlarına `INSTAGRAM_SESSIONID` adıyla ekleyin.
-
-**Not:** `sessionid`'niz zaman zaman geçersiz olabilir. Eğer `sessionid` kullanmanıza rağmen indirme sorunları devam ediyorsa, yeni bir `sessionid` alıp secret'ı güncellemeyi deneyin.
+2.  Geliştirici araçlarını açın.
+3.  `Application` (Chrome/Edge) veya `Storage` (Firefox) sekmesinden `Cookies` > `https://www.instagram.com` yolunu izleyin.
+4.  `sessionid` adlı çerezi bulun ve değerini kopyalayın.
+5.  Bu değeri, forklanmış deponuzdaki GitHub Actions Secrets ayarlarına `INSTAGRAM_SESSIONID` adıyla ekleyin.
 
 ## Dosya Yapısı
 
--   `bot.py`: Ana Telegram bot uygulamasının Python kodunu içerir.
--   `requirements.txt`: Gerekli Python kütüphanelerini listeler.
--   `.github/workflows/main.yml`: Botu zamanlayan ve çalıştıran GitHub Actions iş akışını tanımlar.
+-   `bot.py`: Koyeb üzerinde çalışacak ana Telegram bot uygulaması (GitHub Actions tetikleyicisi).
+-   `requirements.txt`: Koyeb'deki bot için gerekli Python kütüphaneleri.
+-   `.github/workflows/main.yml`: GitHub Actions üzerinde video indirme ve gönderme iş akışını tanımlar.
 -   `README.md`: Bu dosya.
 
 ## Katkıda Bulunma
@@ -94,4 +107,4 @@ Katkılarınızı bekliyoruz! Lütfen bir issue açın veya pull request gönder
 
 ## Lisans
 
-Bu proje MIT Lisansı ile lisanslanmıştır. Detaylar için `LICENSE` dosyasına bakınız (eğer varsa).
+Bu proje MIT Lisansı ile lisanslanmıştır.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 python-telegram-bot==13.7
-yt-dlp
+requests


### PR DESCRIPTION
- Modified GitHub Actions workflow to be triggered via `workflow_dispatch` with `instagram_url` and `chat_id` inputs. The workflow now downloads the video using `yt-dlp` and sends it directly to Telegram via `curl` using a `BOT_TOKEN_FOR_ACTIONS` secret.
- Rewrote `bot.py` (to be deployed on Koyeb) to:
  - Remove video downloading/processing logic.
  - Trigger the GitHub Actions workflow using GitHub API with `GITHUB_PAT`.
  - Manage user interaction and provide feedback.
- Updated `requirements.txt` for the Koyeb bot (removed `yt-dlp`, added `requests`).
- Comprehensively updated `README.md` to reflect the new architecture, detailing setup for Koyeb, GitHub PAT, Actions secrets, and usage flow.