### PR TITLE
Feat: Add manual language selection and multi-image support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ This project is a Python bot that downloads Instagram video links sent via Teleg
 
 ## Features
 
--   Downloads Instagram Reels and video posts using `yt-dlp`.
--   Easy-to-use Telegram bot interface.
+-   Downloads **all media (videos and photos)** from a single Instagram post.
+-   Sends multiple media in a single, clean message group (`MediaGroup`).
+-   Easy-to-use Telegram bot interface with **multi-language support** (TR/EN).
+-   Manual language selection via the `/start` command.
 -   Simple and reliable deployment on Render with `Dockerfile`.
--   Audio support thanks to `ffmpeg` for merging video and audio streams.
+-   Audio support for videos thanks to `ffmpeg`.
 -   Optional `INSTAGRAM_SESSIONID` usage for advanced cases.
--   Multi-language support (English and Turkish).
 
 ## How It Works
 

--- a/README_tr.md
+++ b/README_tr.md
@@ -10,11 +10,13 @@ Bu proje, Telegram üzerinden gönderilen Instagram video linklerini indirip kul
 
 ## Özellikler
 
--   Instagram Reel ve video gönderilerini `yt-dlp` kullanarak indirir.
--   Kullanımı kolay Telegram bot arayüzü.
+-   Tek bir Instagram gönderisindeki **tüm medyaları (video ve fotoğraflar)** indirir.
+-   Birden fazla medyayı tek ve temiz bir mesaj grubu (`MediaGroup`) içinde gönderir.
+-   **Çoklu dil destekli** (TR/EN) kolay kullanım arayüzü.
+-   `/start` komutu ile manuel dil seçimi.
 -   Render üzerinde `Dockerfile` ile kolay ve güvenilir dağıtım (deployment).
 -   `ffmpeg` desteği sayesinde sesli video indirme.
--   Opsiyonel `INSTAGRAM_SESSIONID` kullanımı.
+-   İleri düzey durumlar için opsiyonel `INSTAGRAM_SESSIONID` kullanımı.
 
 ## Nasıl Çalışır?
 

--- a/bot.py
+++ b/bot.py
@@ -6,9 +6,13 @@ from uuid import uuid4
 import time
 import json
 import glob
+from math import ceil
 
-from telegram import Update
-from telegram.ext import Updater, CommandHandler, MessageHandler, Filters, CallbackContext
+from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup, InputMediaPhoto, InputMediaVideo
+from telegram.ext import (
+    Updater, CommandHandler, MessageHandler, Filters, CallbackContext,
+    ConversationHandler, CallbackQueryHandler
+)
 
 # --- TEMEL AYARLAR ---
 logging.basicConfig(format='%(asctime)s - %(name)s - %(levelname)s - %(message)s', level=logging.INFO)
@@ -16,6 +20,11 @@ logger = logging.getLogger(__name__)
 
 # --- ÇOKLU DİL DESTEĞİ ---
 TRANSLATIONS = {}
+# Kullanıcıların dil tercihlerini saklamak için bellek içi sözlük
+# Not: Bot yeniden başladığında bu bilgiler kaybolur.
+USER_LANGS = {}
+# Konuşma durumları
+SELECTING_LANGUAGE = 0
 
 def load_translations():
     """locales klasöründeki tüm .json dosyalarını yükler."""
@@ -30,22 +39,24 @@ def load_translations():
         except Exception as e:
             logger.error(f"{file} dil dosyası yüklenirken hata: {e}")
 
+def get_user_language(update: Update) -> str:
+    """Kullanıcının seçtiği dili alır, yoksa varsayılanı döner."""
+    user_id = update.effective_user.id
+    # Otomatik dil kodunu al, ama öncelik kullanıcının seçimi
+    auto_lang_code = (update.effective_user.language_code or 'en').split('-')[0]
+    return USER_LANGS.get(user_id, auto_lang_code)
+
 def get_translation(lang_code, key, **kwargs):
     """Belirtilen dildeki metni alır, bulamazsa varsayılan dile döner."""
-    # Kullanıcının dil kodunun ilk iki harfini al (örn: 'en_US' -> 'en')
-    base_lang_code = lang_code.split('-')[0] if lang_code else 'en'
-
-    # Önce tam dil kodunu dene, sonra temel dil kodunu, sonra varsayılanı (en)
+    base_lang_code = lang_code.split('-')[0]
     lang_to_try = [lang_code, base_lang_code, 'en']
 
-    message = "Translation key not found." # Varsayılan hata mesajı
+    message = f"Translation key '{key}' not found."
     for lang in lang_to_try:
         if lang in TRANSLATIONS and key in TRANSLATIONS[lang]:
             message = TRANSLATIONS[lang][key]
             break
-
     return message.format(**kwargs)
-
 
 # --- ORTAM DEĞİŞKENLERİ ---
 TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
@@ -64,7 +75,6 @@ def create_cookie_file(session_id_value: str, user_id: str) -> str:
     cookie_line = f".instagram.com\tTRUE\t/\tTRUE\t{expiration_timestamp}\tsessionid\t{session_id_value}\n"
     try:
         with open(cookie_file_path, 'w', encoding='utf-8') as f: f.write(header + cookie_line)
-        logger.info(f"Cookie dosyası oluşturuldu: {cookie_file_path}")
         return cookie_file_path
     except Exception as e:
         logger.error(f"Cookie dosyası oluşturulurken hata: {e}")
@@ -80,90 +90,127 @@ def cleanup_files(*paths):
             logger.error(f"{path} silinirken hata: {e}")
 
 # --- TELEGRAM HANDLER'LARI ---
-def start_command(update: Update, context: CallbackContext):
-    user_lang = update.effective_user.language_code
-    user_name = update.effective_user.first_name
-    welcome_message = get_translation(user_lang, "welcome", user_name=user_name)
-    update.message.reply_html(welcome_message)
+
+# --- Dil Seçimi Conversation ---
+def start(update: Update, context: CallbackContext) -> int:
+    """/start komutu ile dil seçimi başlatır."""
+    keyboard = [
+        [InlineKeyboardButton("Türkçe 🇹🇷", callback_data='tr')],
+        [InlineKeyboardButton("English 🇬🇧", callback_data='en')],
+    ]
+    reply_markup = InlineKeyboardMarkup(keyboard)
+    update.message.reply_text(get_translation('en', 'welcome_prompt'), reply_markup=reply_markup)
+    return SELECTING_LANGUAGE
+
+def language_button(update: Update, context: CallbackContext) -> int:
+    """Dil seçimi butonuna tıklandığında çalışır."""
+    query = update.callback_query
+    query.answer()
+    lang_code = query.data
+    user_id = query.from_user.id
+    user_name = query.from_user.first_name
+
+    USER_LANGS[user_id] = lang_code
+    logger.info(f"Kullanıcı {user_id} dilini '{lang_code}' olarak ayarladı.")
+
+    text = get_translation(lang_code, "language_selected", user_name=user_name)
+    query.edit_message_text(text=text, parse_mode='HTML')
+    return ConversationHandler.END
 
 def link_handler(update: Update, context: CallbackContext):
-    user_lang = update.effective_user.language_code
+    user_lang = get_user_language(update)
     user_id = str(update.effective_user.id)
-    video_url = update.message.text
+    post_url = update.message.text
 
-    if "instagram.com/" not in video_url:
+    if "instagram.com/" not in post_url:
         update.message.reply_text(get_translation(user_lang, "invalid_link"))
         return
 
-    context.bot.send_message(chat_id=user_id, text=get_translation(user_lang, "request_received"))
+    message_to_edit = context.bot.send_message(chat_id=user_id, text=get_translation(user_lang, "request_received"))
 
     cookie_file = create_cookie_file(SESSION_ID, user_id) if SESSION_ID else None
     download_dir = f"temp_dl_{user_id}_{uuid4()}"
     os.makedirs(download_dir, exist_ok=True)
 
-    yt_dlp_command = ['yt-dlp', '--no-warnings', '--force-overwrites', '--no-playlist', '--socket-timeout', '30', '-o', os.path.join(download_dir, '%(id)s.%(ext)s'), '-f', 'bv*[ext=mp4]+ba[ext=m4a]/b[ext=mp4]/bv*+ba/b']
+    # -f (format) parametresini kaldırarak tüm medyaları indir
+    yt_dlp_command = ['yt-dlp', '--no-warnings', '--force-overwrites', '--no-playlist', '--socket-timeout', '60', '-o', os.path.join(download_dir, '%(id)s_%(n)s.%(ext)s')]
     if cookie_file: yt_dlp_command.extend(['--cookies', cookie_file])
-    yt_dlp_command.append(video_url)
+    yt_dlp_command.append(post_url)
 
-    video_path = None
     try:
         process = subprocess.run(yt_dlp_command, capture_output=True, text=True, check=False, timeout=300)
         if process.returncode == 0:
-            downloaded_files = os.listdir(download_dir)
-            if downloaded_files:
-                for f_name in downloaded_files:
-                    if f_name.endswith(('.mp4', '.mkv', '.webm')):
-                        video_path = os.path.join(download_dir, f_name)
-                        break
-                if not video_path: video_path = os.path.join(download_dir, downloaded_files[0])
+            downloaded_files = sorted([os.path.join(download_dir, f) for f in os.listdir(download_dir)])
+            if not downloaded_files:
+                raise FileNotFoundError("yt-dlp klasörü boş.")
 
-                if video_path:
-                    with open(video_path, 'rb') as video_file:
-                        context.bot.send_video(chat_id=user_id, video=video_file, caption=get_translation(user_lang, "download_success_caption"), timeout=120)
-                else:
-                    update.message.reply_text("Video indirildi ancak sunucuda bulunamadı veya formatı tanınmadı.")
-            else:
-                update.message.reply_text(get_translation(user_lang, "error_yt_dlp"))
-                logger.error(f"yt-dlp bir video indirmedi. stderr:\n{process.stderr}")
+            # Medyaları 10'arlı gruplara ayır (Telegram limiti)
+            media_groups = [downloaded_files[i:i + 10] for i in range(0, len(downloaded_files), 10)]
+
+            # İlk mesajı sil veya düzenle
+            message_to_edit.delete()
+
+            for i, group in enumerate(media_groups):
+                media_to_send = []
+                for file_path in group:
+                    if file_path.endswith(('.jpg', '.jpeg', '.png', '.webp')):
+                        media_to_send.append(InputMediaPhoto(media=open(file_path, 'rb')))
+                    elif file_path.endswith(('.mp4', '.mkv', '.webm')):
+                        media_to_send.append(InputMediaVideo(media=open(file_path, 'rb')))
+
+                if media_to_send:
+                    # Sadece ilk gruba başlık ekle
+                    if i == 0:
+                        media_to_send[0].caption = get_translation(user_lang, "download_success_caption")
+
+                    context.bot.send_media_group(chat_id=user_id, media=media_to_send, timeout=180)
         else:
-            logger.error(f"yt-dlp hata kodu: {process.returncode}. stderr:\n{process.stderr}")
-            if "Login required" in process.stderr or "login" in process.stderr.lower() or "Private video" in process.stderr:
-                update.message.reply_text(get_translation(user_lang, "error_private_video"))
-            elif "Unsupported URL" in process.stderr:
-                update.message.reply_text(get_translation(user_lang, "error_unsupported_url"))
-            elif "403" in process.stderr or "Forbidden" in process.stderr:
-                 update.message.reply_text(get_translation(user_lang, "error_forbidden"))
-            else:
-                update.message.reply_text(get_translation(user_lang, "error_yt_dlp"))
-    except subprocess.TimeoutExpired:
-        logger.error("yt-dlp zaman aşımına uğradı.")
-        update.message.reply_text(get_translation(user_lang, "error_timeout"))
+            raise Exception(f"yt-dlp hata kodu: {process.returncode}. stderr: {process.stderr}")
+
     except Exception as e:
-        logger.error(f"Genel indirme hatası (yt-dlp): {e}", exc_info=True)
-        update.message.reply_text(get_translation(user_lang, "error_generic"))
+        message_to_edit.delete()
+        error_text = str(e).lower()
+        logger.error(f"İndirme hatası: {e}")
+        if "login required" in error_text or "private" in error_text:
+            update.message.reply_text(get_translation(user_lang, "error_private_video"))
+        elif "unsupported url" in error_text:
+            update.message.reply_text(get_translation(user_lang, "error_unsupported_url"))
+        elif "403" in error_text or "forbidden" in error_text:
+             update.message.reply_text(get_translation(user_lang, "error_forbidden"))
+        elif "timed out" in error_text:
+            update.message.reply_text(get_translation(user_lang, "error_timeout"))
+        else:
+            update.message.reply_text(get_translation(user_lang, "error_yt_dlp"))
     finally:
         cleanup_files(cookie_file, download_dir)
 
 def error_handler(update: Update, context: CallbackContext):
     logger.error(f"Update '{update}' caused error '{context.error}'", exc_info=context.error)
     if update and update.effective_message:
-        user_lang = update.effective_user.language_code
+        user_lang = get_user_language(update)
         update.effective_message.reply_text(get_translation(user_lang, "error_generic"))
 
 # --- ANA UYGULAMA FONKSİYONU ---
 def main():
-    # Bot başladığında dil dosyalarını yükle
     load_translations()
-
     updater = Updater(TELEGRAM_TOKEN, use_context=True)
     dispatcher = updater.dispatcher
 
-    dispatcher.add_handler(CommandHandler('start', start_command))
-    dispatcher.add_handler(MessageHandler(Filters.text & ~Filters.command & Filters.regex(r'https?://www\.instagram\.com/(p|reel)/\S+'), link_handler))
+    # Dil seçimi için ConversationHandler
+    conv_handler = ConversationHandler(
+        entry_points=[CommandHandler('start', start)],
+        states={
+            SELECTING_LANGUAGE: [CallbackQueryHandler(language_button)],
+        },
+        fallbacks=[CommandHandler('start', start)],
+    )
+
+    dispatcher.add_handler(conv_handler)
+    dispatcher.add_handler(MessageHandler(Filters.text & ~Filters.command & Filters.regex(r'https?://www\.instagram\.com/(p|reel|tv|stories)/\S+'), link_handler))
     dispatcher.add_error_handler(error_handler)
 
     updater.start_polling()
-    logger.info("Bot başlatıldı ve Render üzerinde çalışıyor (çoklu dil destekli).")
+    logger.info("Bot başlatıldı ve Render üzerinde çalışıyor (manuel dil seçimi + çoklu medya).")
     updater.idle()
     logger.info("Bot polling sonlandırıldı, uygulama kapatılıyor.")
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,9 +1,9 @@
 {
-  "welcome": "Hello {user_name}! 👋\n\nJust send me a link to an Instagram Reel or video, and I'll download it for you.\nExample: <code>https://www.instagram.com/p/Cxyz123.../</code>",
+  "welcome_prompt": "Lütfen dilinizi seçin / Please select your language",
+  "language_selected": "✅ Language is set to English.\n\nHello {user_name}! 👋\n\nJust send me a link to an Instagram post (video, image, or reel), and I'll download it for you.\nExample: <code>https://www.instagram.com/p/Cxyz123.../</code>",
   "request_received": "Your request has been received, starting the download process... ⏳ Please wait.",
-  "download_success": "Here is your video! ✅",
-  "download_success_caption": "Here is your video! ✅ (Downloaded with IGXDOWN)",
-  "invalid_link": "Please send a valid Instagram video/reel link.",
+  "download_success_caption": "Here is your media! ✅ (Downloaded with IGXDOWN)",
+  "invalid_link": "Please send a valid Instagram post (video, image, or reel) link.",
   "error_private_video": "This video could not be downloaded. It might be private or require special access. Please make sure the video is public.",
   "error_unsupported_url": "The link you sent appears to be unsupported or invalid.",
   "error_forbidden": "There was a problem accessing Instagram (Access Forbidden). Please try again later.",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -1,9 +1,9 @@
 {
-  "welcome": "Merhaba {user_name}! 👋\n\nInstagram'dan video veya Reel indirmek için bana linkini göndermen yeterli.\nÖrneğin: <code>https://www.instagram.com/p/Cxyz123.../</code>",
+  "welcome_prompt": "Lütfen dilinizi seçin / Please select your language",
+  "language_selected": "✅ Dil Türkçe olarak ayarlandı.\n\nMerhaba {user_name}! 👋\n\nInstagram'dan video, resim veya Reel indirmek için bana linkini göndermen yeterli.\nÖrneğin: <code>https://www.instagram.com/p/Cxyz123.../</code>",
   "request_received": "İsteğiniz alındı, indirme işlemi başlatılıyor... ⏳ Lütfen bekleyin.",
-  "download_success": "İşte videon! ✅",
-  "download_success_caption": "İşte videon! ✅ (IGXDOWN ile indirildi)",
-  "invalid_link": "Lütfen geçerli bir Instagram video/reel linki gönderin.",
+  "download_success_caption": "İşte medyanız! ✅ (IGXDOWN ile indirildi)",
+  "invalid_link": "Lütfen geçerli bir Instagram gönderi (video, resim veya reel) linki gönderin.",
   "error_private_video": "Bu video indirilemedi. Video gizli olabilir veya özel erişim gerektiriyor olabilir. Lütfen videonun herkese açık olduğundan emin olun.",
   "error_unsupported_url": "Gönderdiğiniz link desteklenmiyor veya geçersiz görünüyor.",
   "error_forbidden": "Instagram'a erişimde bir sorun oluştu (Erişim Engellendi). Lütfen daha sonra tekrar deneyin.",


### PR DESCRIPTION
- I implemented a conversation handler for manual language selection (TR/EN) upon /start command.
- I now manage bot messages via JSON files in a `locales` directory.
- I updated `link_handler` to download all media (images and videos) from a post by removing the format filter from the `yt-dlp` command.
- I implemented `send_media_group` to send multiple files to you in a single message, respecting Telegram's 10-item limit per group.
- I updated README files to reflect these new features.