### PR TITLE
Fix: Resolve Render deployment error and improve thread stability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ COPY . .
 # - Gunicorn'u kullanarak Flask uygulamasını başlat.
 # - Render, $PORT ortam değişkenini otomatik olarak sağlar.
 # - bot:app -> bot.py dosyasındaki app adlı Flask nesnesini bulur.
-# - --workers 4: Render'ın planına göre ayarlanabilecek worker sayısı. 1 ile başlamak güvenlidir.
+# - --workers 1: Render'ın ücretsiz planları için 1 worker genellikle yeterlidir.
 # - --timeout 120: Bir worker'ın yanıt vermesi için beklenecek maksimum süre.
-CMD ["gunicorn", "--bind", "0.0.0.0:$PORT", "--workers", "1", "bot:app"]
+# CMD komutunun shell formu, $PORT gibi ortam değişkenlerinin doğru şekilde okunmasını sağlar.
+CMD gunicorn --bind 0.0.0.0:$PORT --workers 1 bot:app

--- a/bot.py
+++ b/bot.py
@@ -183,24 +183,29 @@ def error_handler(update: Update, context: CallbackContext):
 # --- ANA UYGULAMA FONKSİYONU ---
 def run_telegram_bot():
     """Telegram botunu başlatan ve çalıştıran fonksiyon."""
-    if not TELEGRAM_TOKEN:
-        logger.critical("TELEGRAM_TOKEN ortam değişkeni bulunamadı. Bot thread'i başlatılamıyor.")
-        return
+    try:
+        if not TELEGRAM_TOKEN:
+            logger.critical("TELEGRAM_TOKEN ortam değişkeni bulunamadı. Bot thread'i başlatılamıyor.")
+            return
 
-    load_translations()
-    updater = Updater(TELEGRAM_TOKEN, use_context=True)
-    dispatcher = updater.dispatcher
-    conv_handler = ConversationHandler(
-        entry_points=[CommandHandler('start', start)],
-        states={SELECTING_LANGUAGE: [CallbackQueryHandler(language_button)]},
-        fallbacks=[CommandHandler('start', start)],
-    )
-    dispatcher.add_handler(conv_handler)
-    dispatcher.add_handler(MessageHandler(Filters.text & ~Filters.command & Filters.regex(r'https?://www\.instagram\.com/(p|reel|tv|stories)/\S+'), link_handler))
-    dispatcher.add_error_handler(error_handler)
-    updater.start_polling()
-    logger.info("Telegram botu arka planda polling modunda başlatıldı.")
-    updater.idle()
+        load_translations()
+        updater = Updater(TELEGRAM_TOKEN, use_context=True)
+        dispatcher = updater.dispatcher
+        conv_handler = ConversationHandler(
+            entry_points=[CommandHandler('start', start)],
+            states={SELECTING_LANGUAGE: [CallbackQueryHandler(language_button)]},
+            fallbacks=[CommandHandler('start', start)],
+        )
+        dispatcher.add_handler(conv_handler)
+        dispatcher.add_handler(MessageHandler(Filters.text & ~Filters.command & Filters.regex(r'https?://www\.instagram\.com/(p|reel|tv|stories)/\S+'), link_handler))
+        dispatcher.add_error_handler(error_handler)
+        updater.start_polling()
+        logger.info("Telegram botu arka planda polling modunda başlatıldı.")
+        updater.idle()
+    except Exception as e:
+        # Bot thread'inde oluşabilecek herhangi bir kritik hatayı yakala ve logla.
+        # Bu, thread'in sessizce ölmesini engeller ve hatayı görünür kılar.
+        logger.exception("Bot thread'inde yakalanamayan bir istisna oluştu ve thread sonlandırıldı.")
 
 # --- UYGULAMAYI BAŞLATMA ---
 # Gunicorn bu dosyayı import ettiğinde, aşağıdaki kodlar çalışacak ve


### PR DESCRIPTION
- I changed the `CMD` command in the `Dockerfile` to its shell form to correctly parse the `$PORT` environment variable, fixing the 'not a valid port number' error with gunicorn.
- I wrapped the `run_telegram_bot` function in `bot.py` with a try...except block to catch and log any unhandled exceptions in the bot's background thread, preventing it from crashing silently.