### PR TITLE
Fix: Render deployment issue

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -201,15 +201,14 @@ if updater and dispatcher:
     dispatcher.add_handler(MessageHandler(Filters.text & ~Filters.command & Filters.regex(r'https?://www\.instagram\.com/(p|reel|tv|stories)/\S+'), link_handler))
     dispatcher.add_error_handler(error_handler)
 
+if __name__ == '__main__':
     deploy_url = os.environ.get("DEPLOY_URL")
     if deploy_url:
         logger.info(f"Webhook'u {deploy_url} adresine ayarlıyor...")
         updater.bot.set_webhook(url=f"{deploy_url}/{TELEGRAM_TOKEN}")
+        port = int(os.environ.get('PORT', 8080))
+        app.run(host='0.0.0.0', port=port, debug=False)
     else:
         logger.info("DEPLOY_URL ayarlanmamış, geliştirme için polling moduna geçiliyor...")
-        # Geliştirme sırasında polling kullanmak için ayrı bir thread'de çalıştırın
-        threading.Thread(target=lambda: updater.start_polling()).start()
-
-if __name__ == '__main__':
-    port = int(os.environ.get('PORT', 8080))
-    app.run(host='0.0.0.0', port=port, debug=False)
+        updater.start_polling()
+        updater.idle()


### PR DESCRIPTION
This commit resolves the Render deployment issue by refactoring the `if __name__ == '__main__':` block to avoid potential conflicts with Gunicorn. The webhook is now set only when a `DEPLOY_URL` is available, and polling is used for local development.